### PR TITLE
Add multi-region support

### DIFF
--- a/src/deployments/createDeployment.js
+++ b/src/deployments/createDeployment.js
@@ -3,12 +3,19 @@ const platformConfig = require('../config')
 const currentVersion = require('../../package.json').version
 
 const createDeployment = async (data) => {
+  const body = {
+    deployment: {
+      provider: data.provider,
+      region: data.region
+    }
+  }
   const response = await fetch(
     `${platformConfig.backendUrl}tenants/${data.tenant}/applications/${data.app}/services/${
       data.serviceName
     }/deployments`,
     {
       method: 'POST',
+      body: JSON.stringify(body),
       headers: {
         'Content-Type': 'application/json',
         'x-platform-version': currentVersion,

--- a/src/deployments/createDeployment.test.js
+++ b/src/deployments/createDeployment.test.js
@@ -18,10 +18,19 @@ describe('createDeployment', () => {
       tenant: 'sometenant',
       app: 'someapp',
       serviceName: 'someservicename',
-      accessKey: 'someaccesskey'
+      accessKey: 'someaccesskey',
+      provider: 'someprovider',
+      region: 'someregion'
     }
 
     await createDeployment(data)
+
+    const body = {
+      deployment: {
+        provider: data.provider,
+        region: data.region
+      }
+    }
 
     expect(fetch).toBeCalledWith(
       `${platformConfig.backendUrl}tenants/${data.tenant}/applications/${data.app}/services/${
@@ -29,6 +38,7 @@ describe('createDeployment', () => {
       }/deployments`,
       {
         method: 'POST',
+        body: JSON.stringify(body),
         headers: {
           'Content-Type': 'application/json',
           'x-platform-version': currentVersion,

--- a/src/service/archiveService.js
+++ b/src/service/archiveService.js
@@ -3,12 +3,19 @@ const platformConfig = require('../config')
 const currentVersion = require('../../package.json').version
 
 const archiveService = async (data) => {
+  const body = {
+    deployment: {
+      provider: data.provider,
+      region: data.region
+    }
+  }
   const response = await fetch(
     `${platformConfig.backendUrl}tenants/${data.tenant}/applications/${data.app}/services/${
       data.name
     }`,
     {
-      method: 'DELETE',
+      method: 'PUT',
+      body: JSON.stringify(body),
       headers: {
         'Content-Type': 'application/json',
         'x-platform-version': currentVersion,

--- a/src/service/archiveService.test.js
+++ b/src/service/archiveService.test.js
@@ -18,17 +18,27 @@ describe('archiveService', () => {
       app: 'someapp',
       tenant: 'sometenant',
       name: 'somename',
-      accessKey: 'someaccesskey'
+      accessKey: 'someaccesskey',
+      provider: 'someprovider',
+      region: 'someregion'
     }
 
     await archiveService(data)
+
+    const body = {
+      deployment: {
+        provider: data.provider,
+        region: data.region
+      }
+    }
 
     expect(fetch).toBeCalledWith(
       `${platformConfig.backendUrl}tenants/${data.tenant}/applications/${data.app}/services/${
         data.name
       }`,
       {
-        method: 'DELETE',
+        method: 'PUT',
+        body: JSON.stringify(body),
         headers: {
           'Content-Type': 'application/json',
           'x-platform-version': currentVersion,


### PR DESCRIPTION
Adds multi-region awareness so that one can create deployments in multiple regions and archive services on a per-region basis.

Framework PR --> https://github.com/serverless/serverless/pull/5218