### PR TITLE
prerelease CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-- 10
+- '10.15'
 - 8
 - 6
 before_install:
@@ -13,13 +13,40 @@ script:
 - npm run test:ci
 before_deploy:
 - snyk monitor --org=serverless
+- node ./scripts/updatePreReleaseVersion.js
 deploy:
-  provider: npm
-  email: services@serverless.com
-  skip_cleanup: true
-  tag: next # remove when no longer a beta release
-  on:
-    tags: true
-    repo: serverless/platform-sdk
-  api_key:
-    secure: yJpF/tiiirgm0WEuoO4M1MrqYyJ63IwTHnBvv32ZyJCaOg3hUT2thVCtPtecMfPM2xPC679iZj5278KfHDc7xLMcGfH+LMN9M42KsExBKODq/Xj/h9k0l5jmxQYcQzncRVr7x1pf/GYzZYv2pk0noxsK3tmueuCJNA2M5t0mHQBuWltm7kX4vOjIbIHhiPrlKjfQG2ShKpZ4CeWbdfIjtBgT4U+PQggRPfZ+cmOHlst38M/7F2HBf65GTkpQUN+IXuJ0NELgqBDUpLT3hA8il+znFCRWES1M81WtknC9AVhD4JNV+udeIFD7caAhBzMDAcUdukHyMCTT3XScwgRwutB50J7xEmRm/mqD7dSVbBAz/FUO28W+/chdSWIg1FgRVTzCxSD0SUx3+VnsVH5hElDtTgcfh7Se6smZno7UrWzw/DPSlXOmd12Ucn0MKlqBbAXIdZuGFOMsTxsR5Rvz4WX8qTdbGTN02dqfjI/xRi/wO9ho13pabVIHRBBTSNh8Y2iWu+hO1vn5AoAsZYIboaJDc0iq/8qOe+l474qVCF+gHnAboa9xBBIqv2zCJjzzDlKZcp6MMdwCe3M6QW2IsvOsBNxtThABiNLCBro812mfaaigUwEiQYfhGU9U2T85djS2J2+UosjnODqLUivHy1qN2Ku+U66e6MECXEZrwxA=
+  # production releases
+  - provider: npm
+    email: services@serverless.com
+    skip_cleanup: true
+    tag: latest
+    on:
+      node: 10.15
+      tags: true
+      condition: '! "$TRAVIS_TAG" =~ beta'
+      repo: serverless/platform-sdk
+    api_key:
+      secure: yJpF/tiiirgm0WEuoO4M1MrqYyJ63IwTHnBvv32ZyJCaOg3hUT2thVCtPtecMfPM2xPC679iZj5278KfHDc7xLMcGfH+LMN9M42KsExBKODq/Xj/h9k0l5jmxQYcQzncRVr7x1pf/GYzZYv2pk0noxsK3tmueuCJNA2M5t0mHQBuWltm7kX4vOjIbIHhiPrlKjfQG2ShKpZ4CeWbdfIjtBgT4U+PQggRPfZ+cmOHlst38M/7F2HBf65GTkpQUN+IXuJ0NELgqBDUpLT3hA8il+znFCRWES1M81WtknC9AVhD4JNV+udeIFD7caAhBzMDAcUdukHyMCTT3XScwgRwutB50J7xEmRm/mqD7dSVbBAz/FUO28W+/chdSWIg1FgRVTzCxSD0SUx3+VnsVH5hElDtTgcfh7Se6smZno7UrWzw/DPSlXOmd12Ucn0MKlqBbAXIdZuGFOMsTxsR5Rvz4WX8qTdbGTN02dqfjI/xRi/wO9ho13pabVIHRBBTSNh8Y2iWu+hO1vn5AoAsZYIboaJDc0iq/8qOe+l474qVCF+gHnAboa9xBBIqv2zCJjzzDlKZcp6MMdwCe3M6QW2IsvOsBNxtThABiNLCBro812mfaaigUwEiQYfhGU9U2T85djS2J2+UosjnODqLUivHy1qN2Ku+U66e6MECXEZrwxA=
+  # tagged prereleases
+  - provider: npm
+    email: services@serverless.com
+    skip_cleanup: true
+    tag: next
+    on:
+      node: 10.15
+      tags: true
+      condition: '"$TRAVIS_TAG" =~ beta'
+      repo: serverless/platform-sdk
+    api_key:
+      secure: yJpF/tiiirgm0WEuoO4M1MrqYyJ63IwTHnBvv32ZyJCaOg3hUT2thVCtPtecMfPM2xPC679iZj5278KfHDc7xLMcGfH+LMN9M42KsExBKODq/Xj/h9k0l5jmxQYcQzncRVr7x1pf/GYzZYv2pk0noxsK3tmueuCJNA2M5t0mHQBuWltm7kX4vOjIbIHhiPrlKjfQG2ShKpZ4CeWbdfIjtBgT4U+PQggRPfZ+cmOHlst38M/7F2HBf65GTkpQUN+IXuJ0NELgqBDUpLT3hA8il+znFCRWES1M81WtknC9AVhD4JNV+udeIFD7caAhBzMDAcUdukHyMCTT3XScwgRwutB50J7xEmRm/mqD7dSVbBAz/FUO28W+/chdSWIg1FgRVTzCxSD0SUx3+VnsVH5hElDtTgcfh7Se6smZno7UrWzw/DPSlXOmd12Ucn0MKlqBbAXIdZuGFOMsTxsR5Rvz4WX8qTdbGTN02dqfjI/xRi/wO9ho13pabVIHRBBTSNh8Y2iWu+hO1vn5AoAsZYIboaJDc0iq/8qOe+l474qVCF+gHnAboa9xBBIqv2zCJjzzDlKZcp6MMdwCe3M6QW2IsvOsBNxtThABiNLCBro812mfaaigUwEiQYfhGU9U2T85djS2J2+UosjnODqLUivHy1qN2Ku+U66e6MECXEZrwxA=
+  # automatic prereleases
+  - provider: npm
+    email: services@serverless.com
+    skip_cleanup: true
+    tag: next
+    on:
+      node: 10.15
+      tags: false
+      repo: serverless/platform-sdk
+    api_key:
+      secure: yJpF/tiiirgm0WEuoO4M1MrqYyJ63IwTHnBvv32ZyJCaOg3hUT2thVCtPtecMfPM2xPC679iZj5278KfHDc7xLMcGfH+LMN9M42KsExBKODq/Xj/h9k0l5jmxQYcQzncRVr7x1pf/GYzZYv2pk0noxsK3tmueuCJNA2M5t0mHQBuWltm7kX4vOjIbIHhiPrlKjfQG2ShKpZ4CeWbdfIjtBgT4U+PQggRPfZ+cmOHlst38M/7F2HBf65GTkpQUN+IXuJ0NELgqBDUpLT3hA8il+znFCRWES1M81WtknC9AVhD4JNV+udeIFD7caAhBzMDAcUdukHyMCTT3XScwgRwutB50J7xEmRm/mqD7dSVbBAz/FUO28W+/chdSWIg1FgRVTzCxSD0SUx3+VnsVH5hElDtTgcfh7Se6smZno7UrWzw/DPSlXOmd12Ucn0MKlqBbAXIdZuGFOMsTxsR5Rvz4WX8qTdbGTN02dqfjI/xRi/wO9ho13pabVIHRBBTSNh8Y2iWu+hO1vn5AoAsZYIboaJDc0iq/8qOe+l474qVCF+gHnAboa9xBBIqv2zCJjzzDlKZcp6MMdwCe3M6QW2IsvOsBNxtThABiNLCBro812mfaaigUwEiQYfhGU9U2T85djS2J2+UosjnODqLUivHy1qN2Ku+U66e6MECXEZrwxA=

--- a/scripts/updatePreReleaseVersion.js
+++ b/scripts/updatePreReleaseVersion.js
@@ -1,0 +1,25 @@
+// This is only for use in CI to set the version number in package.json
+// for publishing prerelease versions to npm
+
+const { spawnSync } = require('child_process')
+const { writeFileSync, readFileSync } = require('fs')
+const semver = require('semver')
+
+const packageJson = JSON.parse(readFileSync('package.json').toString())
+
+const version = semver.valid(
+  spawnSync('git', ['describe', '--tags'])
+    .stdout.toString()
+    .slice(0, -1)
+)
+
+if (!semver.gt(packageJson.version, version)) {
+  packageJson.version = version
+  writeFileSync('package.json', JSON.stringify(packageJson, null, 2) + '\n')
+} else {
+  // eslint-disable-next-line no-console
+  console.error(`Error: ${packageJson.version} greater than ${version}
+You need to make a tagged release or pre-release to continue 
+making automatic prereleases after updating the version number`)
+  process.exit(1)
+}


### PR DESCRIPTION
* Normal tags, published to `latest` tag
* Commits to master run the `updatePreReleaseVersion.js` which changes the version number to the output of `git describe --tags` which is `LATEST_TAG-NUM_COMMITS_SINCE_TAG-HASH`, eg: `v0.3.0-1-HHHHHH` or if a beta(next bullet) has been publisehd `v0.4.0-beta-1-HHHHHH`. It is then published to the `next` tag on npm This allows for testing the latest version of master via the `next` tag on npm.
* Tags containing `beta` are published to the `next` tag on NPM. This will allow testing of things that check against version number changes.

I tested this via the platform plugin since it is a private project for now, and it works as expected. https://www.npmjs.com/package/@serverless/platform-plugin https://travis-ci.com/serverless/platform-plugin/branches (beta is latest not next because i published that before devising this scheme)

Combined with https://github.com/serverless/platform-plugin/pull/12 will make using dev platform as simple as:
```
npm i @serverless/platform-plugin@next
SERVERLESS_PLATFORM_STAGE=dev sls deploy
```
