### PR TITLE
Send authorization when creating/removing log destinations

### DIFF
--- a/src/logs/createDestination.js
+++ b/src/logs/createDestination.js
@@ -1,5 +1,6 @@
 import fetch from 'isomorphic-fetch'
 import platformConfig from '../config'
+const { getUser } = require('../rcfile')
 
 const createDestination = async ({
   tenantUid,
@@ -7,8 +8,17 @@ const createDestination = async ({
   serviceName,
   stageName,
   regionName,
-  accountId
+  accountId,
+  token
 }) => {
+  if (!token) {
+    const user = getUser()
+    if (!user) {
+      return Promise.reject('User is not logged in to the Platform.')
+    }
+    token = user.idToken
+  }
+
   const body = JSON.stringify({
     tenantUid,
     appUid,
@@ -22,7 +32,8 @@ const createDestination = async ({
     method: 'POST',
     body,
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      Authorization: `bearer ${token}`
     }
   })
 

--- a/src/logs/createDestination.test.js
+++ b/src/logs/createDestination.test.js
@@ -11,6 +11,10 @@ jest.mock('isomorphic-fetch', () =>
   )
 )
 
+jest.mock('../rcfile', () => ({
+  getUser: jest.fn().mockReturnValue({ idToken: 'userIdToken' })
+}))
+
 afterAll(() => jest.restoreAllMocks())
 
 describe('getLogDestination', () => {
@@ -36,6 +40,7 @@ describe('getLogDestination', () => {
         accountId: 'ACCOUNT_ID'
       }),
       headers: {
+        Authorization: 'userIdToken',
         'Content-Type': 'application/json'
       }
     })

--- a/src/logs/createDestination.test.js
+++ b/src/logs/createDestination.test.js
@@ -40,7 +40,7 @@ describe('getLogDestination', () => {
         accountId: 'ACCOUNT_ID'
       }),
       headers: {
-        Authorization: 'userIdToken',
+        Authorization: 'bearer userIdToken',
         'Content-Type': 'application/json'
       }
     })

--- a/src/logs/removeDestination.js
+++ b/src/logs/removeDestination.js
@@ -1,7 +1,23 @@
 import fetch from 'isomorphic-fetch'
 import platformConfig from '../config'
+const { getUser } = require('../rcfile')
 
-const removeLogDestination = async ({ tenantUid, appUid, serviceName, stageName, regionName }) => {
+const removeLogDestination = async ({
+  tenantUid,
+  appUid,
+  serviceName,
+  stageName,
+  regionName,
+  token
+}) => {
+  if (!token) {
+    const user = getUser()
+    if (!user) {
+      return Promise.reject('User is not logged in to the Platform.')
+    }
+    token = user.idToken
+  }
+
   const body = JSON.stringify({
     tenantUid,
     appUid,
@@ -14,7 +30,8 @@ const removeLogDestination = async ({ tenantUid, appUid, serviceName, stageName,
     method: 'POST',
     body,
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      Authorization: `bearer ${token}`
     }
   })
 

--- a/src/logs/removeDestination.test.js
+++ b/src/logs/removeDestination.test.js
@@ -11,6 +11,10 @@ jest.mock('isomorphic-fetch', () =>
   )
 )
 
+jest.mock('../rcfile', () => ({
+  getUser: jest.fn().mockReturnValue({ idToken: 'userIdToken' })
+}))
+
 afterAll(() => jest.restoreAllMocks())
 
 describe('removeLogDestination', () => {

--- a/src/logs/removeDestination.test.js
+++ b/src/logs/removeDestination.test.js
@@ -39,6 +39,7 @@ describe('removeLogDestination', () => {
         regionName: 'region'
       }),
       headers: {
+        Authorization: 'bearer userIdToken',
         'Content-Type': 'application/json'
       }
     })


### PR DESCRIPTION
Send the ID token when calling the Log Destinations endpoints.

This could use the access key instead, but right now it's not trivial to get access (hm...) to the access key within the SDK code, and Austen's work to move platform logic out of the Framework introduces some utilities to ease that.

At some point we need to go through all these SDK's uses of ID token and replace them wherever possible with access key, for headless/CI use. For now though, the API doesn't care whether it receives the ID token or access key, so we can go ahead with this.