### PR TITLE
[XXxxxxx] - Don't write to config file if the tenant name has not been populated in the scenario of a new user

### DIFF
--- a/src/accessKeys/accessKeys.test.js
+++ b/src/accessKeys/accessKeys.test.js
@@ -1,0 +1,63 @@
+import { getAccessKeyForTenant } from './accessKeys'
+
+jest.mock('../utils', () => ({
+  readConfigFile: jest.fn().mockReturnValue({
+    userId: 'userId',
+    users: {
+      userId: {
+        dashboard: {
+          expiresAt: 1548263344735 - 10000,
+          refreshToken: 'refreshToken'
+        }
+      }
+    }
+  }),
+  writeConfigFile: jest.fn().mockReturnValue(),
+  checkHttpResponse: jest.fn(),
+  getLoggedInUser: jest
+    .fn()
+    .mockReturnValue({ accessKeys: { foo: 'hgVH317YAhZSL7ptW9zGfC9V061hV9cL' } })
+}))
+
+describe('getAccessKeyForTenant', () => {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules() // this is important
+    process.env = { ...OLD_ENV }
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+
+  it('should return the serverless access key', async () => {
+    process.env.SERVERLESS_ACCESS_KEY = 'hgVH317YAhZSL7ptW9zGfC9V061hV9cL'
+
+    const result = await getAccessKeyForTenant('tenant')
+    expect(result).toEqual('hgVH317YAhZSL7ptW9zGfC9V061hV9cL')
+  })
+
+  it('should throw an error when tenant is not defined', async () => {
+    try {
+      await getAccessKeyForTenant('')
+    } catch (e) {
+      expect.arrayContaining(['Error: SDK: getAccessKeyForTenant() requires a "tenant".'])
+    }
+  })
+
+  it('should throw an error when a user does not have an access key', async () => {
+    try {
+      await getAccessKeyForTenant('foo')
+    } catch (e) {
+      expect.arrayContaining([
+        'Error: Could not find an access key for tenant foo.  Log out and log in again to create a new access key for this tenant.'
+      ])
+    }
+  })
+
+  it('should return the access key for a user and tenant', async () => {
+    const result = await getAccessKeyForTenant('foo')
+    expect(result).toEqual('hgVH317YAhZSL7ptW9zGfC9V061hV9cL')
+  })
+})

--- a/src/accessKeys/accessKeys.test.js
+++ b/src/accessKeys/accessKeys.test.js
@@ -1,4 +1,20 @@
-import { getAccessKeyForTenant } from './accessKeys'
+import { getAccessKeyForTenant, createAccessKeyForTenant } from './accessKeys'
+
+jest.mock('../fetch', () =>
+  jest.fn().mockReturnValue(
+    Promise.resolve({
+      ok: true,
+      json: jest.fn().mockReturnValue(
+        Promise.resolve({
+          id_token: 'id_token',
+          access_token: 'access_token',
+          secretAccessKey: 'secret_access_key',
+          expires_in: 10000
+        })
+      )
+    })
+  )
+)
 
 jest.mock('../utils', () => ({
   readConfigFile: jest.fn().mockReturnValue({
@@ -14,9 +30,10 @@ jest.mock('../utils', () => ({
   }),
   writeConfigFile: jest.fn().mockReturnValue(),
   checkHttpResponse: jest.fn(),
-  getLoggedInUser: jest
-    .fn()
-    .mockReturnValue({ accessKeys: { foo: 'hgVH317YAhZSL7ptW9zGfC9V061hV9cL' } })
+  getLoggedInUser: jest.fn().mockReturnValue({
+    accessKeys: { foo: 'serverless_access_key' },
+    idToken: 'id_token'
+  })
 }))
 
 describe('getAccessKeyForTenant', () => {
@@ -32,10 +49,10 @@ describe('getAccessKeyForTenant', () => {
   })
 
   it('should return the serverless access key', async () => {
-    process.env.SERVERLESS_ACCESS_KEY = 'hgVH317YAhZSL7ptW9zGfC9V061hV9cL'
+    process.env.SERVERLESS_ACCESS_KEY = 'serverless_access_key'
 
     const result = await getAccessKeyForTenant('tenant')
-    expect(result).toEqual('hgVH317YAhZSL7ptW9zGfC9V061hV9cL')
+    expect(result).toEqual('serverless_access_key')
   })
 
   it('should throw an error when tenant is not defined', async () => {
@@ -58,6 +75,13 @@ describe('getAccessKeyForTenant', () => {
 
   it('should return the access key for a user and tenant', async () => {
     const result = await getAccessKeyForTenant('foo')
-    expect(result).toEqual('hgVH317YAhZSL7ptW9zGfC9V061hV9cL')
+    expect(result).toEqual('serverless_access_key')
+  })
+})
+
+describe('createAccessKeyForTenant', () => {
+  it('should fetch an access key', async () => {
+    const result = await createAccessKeyForTenant('foo', 'foobar')
+    expect(result).toEqual('secret_access_key')
   })
 })

--- a/src/login/getTokens.test.js
+++ b/src/login/getTokens.test.js
@@ -1,0 +1,29 @@
+import getTokens from './getTokens'
+
+jest.mock('../fetch', () =>
+  jest.fn().mockReturnValue(
+    Promise.resolve({
+      ok: true,
+      json: jest.fn().mockReturnValue(
+        Promise.resolve({
+          id_token: 'id_token',
+          access_token: 'access_token',
+          secretAccessKey: 'secret_access_key',
+          expires_in: 10000
+        })
+      )
+    })
+  )
+)
+
+describe('getTokens', () => {
+  it('should get the tokens', async () => {
+    const result = await getTokens('code')
+    expect(result).toEqual({
+      access_token: 'access_token',
+      expires_in: 10000,
+      id_token: 'id_token',
+      secretAccessKey: 'secret_access_key'
+    })
+  })
+})

--- a/src/login/login.js
+++ b/src/login/login.js
@@ -55,13 +55,12 @@ const login = async (tenant) => {
         opnRes.kill()
       }
 
-      if (req.query.statusCode) {
-        if (req.query.statusCode === '412') {
-          res.end()
-          server.close()
-          return reject('Please verify your email before proceeding.')
-        }
+      if (req.query.unverified) {
+        res.end()
+        server.close()
+        return reject('Complete sign-up before logging in.')
       }
+
       if (req.query.code) {
         const tokens = await getTokens(req.query.code)
         refreshToken = tokens.refresh_token

--- a/src/login/login.js
+++ b/src/login/login.js
@@ -48,10 +48,19 @@ const login = async (tenant) => {
   const opnRes = await openBrowser(auth0Endpoint)
 
   // Log in to Serverless Enterprise
-  return new Promise((resolve) => {
-    app.get('/', async (req, res) => { // eslint-disable-line
+  return new Promise((resolve, reject) => {
+    app.get('/', async (req, res) => {
+      // eslint-disable-line
       if (opnRes) {
         opnRes.kill()
+      }
+
+      if (req.query.statusCode) {
+        if (req.query.statusCode === '412') {
+          res.end()
+          server.close()
+          return reject('Please verify your email before proceeding.')
+        }
       }
       if (req.query.code) {
         const tokens = await getTokens(req.query.code)

--- a/src/login/login.js
+++ b/src/login/login.js
@@ -111,7 +111,7 @@ const login = async (tenant) => {
 
     // If tenant is included, update config w/ new accesskey for that tenant
     let accessKey
-    if (tenant) {
+    if (tenant && tenant !== 'tenantname') {
       accessKey = await createAccessKeyForTenant(tenant)
       if (accessKey) {
         configFile = utils.readConfigFile()


### PR DESCRIPTION
Without the following check the tenant "tenantname" will be picked up from the yml and cause an unauthorized error for the tenant. We should avoid this. 