### PR TITLE
Onboarding sdk funcs

### DIFF
--- a/src/apps/getApps.js
+++ b/src/apps/getApps.js
@@ -3,11 +3,7 @@ import platformConfig from '../config'
 import { getAccessKeyForTenant } from '../accessKeys'
 
 const getApps = async (data) => {
-  let { token } = data
-
-  if (!token) {
-    token = await getAccessKeyForTenant(data.tenant)
-  }
+  const token = data.token || (await getAccessKeyForTenant(data.tenant))
 
   const response = await fetch(`${platformConfig.backendUrl}tenants/${data.tenant}/applications`, {
     method: 'GET',

--- a/src/apps/getApps.js
+++ b/src/apps/getApps.js
@@ -1,0 +1,22 @@
+import fetch from '../fetch'
+import platformConfig from '../config'
+import { getAccessKeyForTenant } from '../accessKeys'
+
+const getApps = async (data) => {
+  let { token } = data
+
+  if (!token) {
+    token = await getAccessKeyForTenant(data.tenant)
+  }
+
+  const response = await fetch(`${platformConfig.backendUrl}tenants/${data.tenant}/applications`, {
+    method: 'GET',
+    headers: {
+      Authorization: `bearer ${token}`
+    }
+  })
+
+  return response.json()
+}
+
+export default getApps

--- a/src/apps/getApps.test.js
+++ b/src/apps/getApps.test.js
@@ -1,0 +1,63 @@
+import { getApps } from './'
+import fetch from 'isomorphic-fetch'
+import platformConfig from '../config'
+import refreshToken from '../login/refreshToken'
+
+jest.mock('isomorphic-fetch', () =>
+  jest.fn().mockReturnValue({
+    ok: true,
+    json: async () => {}
+  })
+)
+
+jest.mock('../utils', () => ({
+  getLoggedInUser: jest.fn().mockReturnValue({
+    accessKeys: {
+      sometenant: 'userAccessKey'
+    }
+  }),
+  checkHttpResponse: jest.fn()
+}))
+
+jest.mock('../login/refreshToken', () => jest.fn().mockReturnValue())
+
+afterAll(() => jest.restoreAllMocks())
+
+describe('getApps', () => {
+  test('it should make a valid request without a provided token', async () => {
+    const data = {
+      app: 'someapp',
+      tenant: 'sometenant'
+    }
+
+    await getApps(data)
+
+    expect(fetch).toBeCalledWith(
+      `${platformConfig.backendUrl}tenants/${data.tenant}/applications`,
+      {
+        method: 'GET',
+        headers: { Authorization: `bearer userAccessKey` }
+      }
+    )
+    expect(refreshToken).toBeCalledWith()
+  })
+
+  test('it should make a valid request with a provided token', async () => {
+    const data = {
+      app: 'someapp',
+      tenant: 'sometenant',
+      token: 'mytoken'
+    }
+
+    await getApps(data)
+
+    expect(fetch).toBeCalledWith(
+      `${platformConfig.backendUrl}tenants/${data.tenant}/applications`,
+      {
+        method: 'GET',
+        headers: { Authorization: `bearer mytoken` }
+      }
+    )
+    expect(refreshToken).toBeCalledWith()
+  })
+})

--- a/src/apps/index.js
+++ b/src/apps/index.js
@@ -1,2 +1,3 @@
 export { default as createApp } from './createApp'
 export { default as getApp } from './getApp'
+export { default as getApps } from './getApps'

--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,14 @@ const safeguards = require('./safeguards')
 const urls = require('./config')
 const { configureFetchDefaults } = require('./fetch')
 const core = require('./core')
+const register = require('./register')
 const deployProfiles = require('./deployProfiles')
 const stateVariables = require('./stateVariables')
 
 module.exports = {
   Deployment,
   ...core,
+  ...register,
   ...service,
   ...apps,
   ...tenants,

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -1,0 +1,1 @@
+export { default as register } from './register'

--- a/src/register/register.js
+++ b/src/register/register.js
@@ -1,0 +1,13 @@
+import fetch from '../fetch'
+import platformConfig from '../config'
+
+const register = async (email, password) => {
+  const response = await fetch(`${platformConfig.backendUrl}register`, {
+    method: 'POST',
+    body: JSON.stringify({ email, password })
+  })
+
+  return response.json()
+}
+
+module.exports = register

--- a/src/register/register.js
+++ b/src/register/register.js
@@ -1,10 +1,16 @@
 import fetch from '../fetch'
 import platformConfig from '../config'
 
-const register = async (email, password) => {
-  const response = await fetch(`${platformConfig.backendUrl}register`, {
+const register = async (email, password, username, tenantName, tenantTitle) => {
+  const response = await fetch(`${platformConfig.backendUrl}tenant`, {
     method: 'POST',
-    body: JSON.stringify({ email, password })
+    body: JSON.stringify({
+      tenantName,
+      title: tenantTitle,
+      ownerUserName: username,
+      ownerPassword: password,
+      ownerEmail: email
+    })
   })
 
   return response.json()

--- a/src/register/register.test.js
+++ b/src/register/register.test.js
@@ -12,12 +12,18 @@ jest.mock('isomorphic-fetch', () =>
 
 describe('register', () => {
   it('posts to register endpoint', async () => {
-    const response = await register('sue@example.com', 'hunter2')
+    const response = await register('sue@example.com', 'hunter2', 'su', 'su-ten', "sue's tenant")
     expect(response).toEqual({ accountId: '11111' })
-    expect(fetch).toBeCalledWith('https://api.serverless.com/core/register', {
+    expect(fetch).toBeCalledWith('https://api.serverless.com/core/tenant', {
       method: 'POST',
       headers: {},
-      body: JSON.stringify({ email: 'sue@example.com', password: 'hunter2' })
+      body: JSON.stringify({
+        tenantName: 'su-ten',
+        title: "sue's tenant",
+        ownerUserName: 'su',
+        ownerPassword: 'hunter2',
+        ownerEmail: 'sue@example.com'
+      })
     })
   })
 })

--- a/src/register/register.test.js
+++ b/src/register/register.test.js
@@ -1,0 +1,23 @@
+import { register } from './'
+import fetch from 'isomorphic-fetch'
+
+jest.mock('isomorphic-fetch', () =>
+  jest.fn().mockReturnValue(
+    Promise.resolve({
+      ok: true,
+      json: jest.fn().mockReturnValue(Promise.resolve({ accountId: '11111' }))
+    })
+  )
+)
+
+describe('register', () => {
+  it('posts to register endpoint', async () => {
+    const response = await register('sue@example.com', 'hunter2')
+    expect(response).toEqual({ accountId: '11111' })
+    expect(fetch).toBeCalledWith('https://api.serverless.com/core/register', {
+      method: 'POST',
+      headers: {},
+      body: JSON.stringify({ email: 'sue@example.com', password: 'hunter2' })
+    })
+  })
+})

--- a/src/service/archiveService.js
+++ b/src/service/archiveService.js
@@ -7,9 +7,7 @@ const archiveService = async (data) => {
     region: data.region
   }
   const response = await fetch(
-    `${platformConfig.backendUrl}tenants/${data.tenant}/applications/${data.app}/services/${
-      data.name
-    }`,
+    `${platformConfig.backendUrl}tenants/${data.tenant}/applications/${data.app}/services/${data.name}`,
     {
       method: 'PUT',
       body: JSON.stringify(body),

--- a/src/service/archiveService.test.js
+++ b/src/service/archiveService.test.js
@@ -30,9 +30,7 @@ describe('archiveService', () => {
     }
 
     expect(fetch).toBeCalledWith(
-      `${platformConfig.backendUrl}tenants/${data.tenant}/applications/${data.app}/services/${
-        data.name
-      }`,
+      `${platformConfig.backendUrl}tenants/${data.tenant}/applications/${data.app}/services/${data.name}`,
       {
         method: 'PUT',
         body: JSON.stringify(body),

--- a/src/service/getServiceUrl.js
+++ b/src/service/getServiceUrl.js
@@ -1,9 +1,7 @@
 import platformConfig from '../config'
 
 const getServiceUrl = (data) => {
-  return `${platformConfig.frontendUrl}tenants/${data.tenant}/applications/${data.app}/services/${
-    data.name
-  }`
+  return `${platformConfig.frontendUrl}tenants/${data.tenant}/applications/${data.app}/services/${data.name}`
 }
 
 export default getServiceUrl

--- a/src/service/getServiceUrl.test.js
+++ b/src/service/getServiceUrl.test.js
@@ -12,9 +12,7 @@ describe('getServiceUrl', () => {
     const serviceUrl = getServiceUrl(data)
 
     expect(serviceUrl).toEqual(
-      `${platformConfig.frontendUrl}tenants/${data.tenant}/applications/${data.app}/services/${
-        data.name
-      }`
+      `${platformConfig.frontendUrl}tenants/${data.tenant}/applications/${data.app}/services/${data.name}`
     )
   })
 })

--- a/src/stateVariables/index.js
+++ b/src/stateVariables/index.js
@@ -11,9 +11,7 @@ export const getStateVariable = async ({
   region
 }) => {
   const response = await fetch(
-    `${
-      platformConfig.backendUrl
-    }tenants/${tenant}/applications/${app}/services/${service}/stages/${stage}/regions/${region}/outputs`,
+    `${platformConfig.backendUrl}tenants/${tenant}/applications/${app}/services/${service}/stages/${stage}/regions/${region}/outputs`,
     {
       method: 'POST',
       headers: { Authorization: `bearer ${accessKey}` },

--- a/src/tenants/createTenant.js
+++ b/src/tenants/createTenant.js
@@ -4,7 +4,7 @@ import platformConfig from '../config'
 const createTenant = async (data) => {
   await fetch(`${platformConfig.backendUrl}tenants`, {
     method: 'POST',
-    headers: { Authorization: `bearer ${data.idToken}` },
+    headers: { Authorization: `bearer ${data.token}` },
     body: JSON.stringify({
       title: data.title,
       tenantName: data.tenant,

--- a/src/tenants/createTenant.js
+++ b/src/tenants/createTenant.js
@@ -1,0 +1,16 @@
+import fetch from '../fetch'
+import platformConfig from '../config'
+
+const createTenant = async (data) => {
+  await fetch(`${platformConfig.backendUrl}tenants`, {
+    method: 'POST',
+    headers: { Authorization: `bearer ${data.idToken}` },
+    body: JSON.stringify({
+      title: data.title,
+      tenantName: data.tenant,
+      ownerUserName: data.ownerUserName
+    })
+  })
+}
+
+export default createTenant

--- a/src/tenants/createTenant.test.js
+++ b/src/tenants/createTenant.test.js
@@ -17,14 +17,14 @@ describe('createTenant', () => {
       title: 'foo-bar',
       tenant: 'foobar',
       ownerUserName: 'someusername',
-      idToken: 'someIdToken'
+      token: 'someIdToken'
     }
 
     await createTenant(data)
 
     expect(fetch).toBeCalledWith(`${platformConfig.backendUrl}tenants`, {
       method: 'POST',
-      headers: { Authorization: `bearer ${data.idToken}` },
+      headers: { Authorization: `bearer ${data.token}` },
       body: JSON.stringify({
         title: data.title,
         tenantName: data.tenant,

--- a/src/tenants/createTenant.test.js
+++ b/src/tenants/createTenant.test.js
@@ -1,0 +1,35 @@
+import { createTenant } from './'
+import fetch from 'isomorphic-fetch'
+import platformConfig from '../config'
+
+jest.mock('isomorphic-fetch', () =>
+  jest.fn().mockReturnValue({
+    ok: true,
+    json: async () => {}
+  })
+)
+
+afterAll(() => jest.restoreAllMocks())
+
+describe('createTenant', () => {
+  test('it should make a valid request', async () => {
+    const data = {
+      title: 'foo-bar',
+      tenant: 'foobar',
+      ownerUserName: 'someusername',
+      idToken: 'someIdToken'
+    }
+
+    await createTenant(data)
+
+    expect(fetch).toBeCalledWith(`${platformConfig.backendUrl}tenants`, {
+      method: 'POST',
+      headers: { Authorization: `bearer ${data.idToken}` },
+      body: JSON.stringify({
+        title: data.title,
+        tenantName: data.tenant,
+        ownerUserName: data.ownerUserName
+      })
+    })
+  })
+})

--- a/src/tenants/index.js
+++ b/src/tenants/index.js
@@ -1,1 +1,2 @@
 export { default as listTenants } from './listTenants' // eslint-disable-line
+export { default as createTenant } from './createTenant' // eslint-disable-line


### PR DESCRIPTION
There already was a `createApp` function.
Added:
 * `getApps`
 * `createTenant`
 * `registerUser`

how to use:
```javascript
import { createApp, getApps, createTenant, registerUser, getLoggedInuser } from '@serverless/platform-sdk'

const registerResp = await registerUser('email@example.com', 'password')
// response contents of that are still TBD


const { idToken, username } = getLoggedInUser()
await createTenant({
  title: 'newww',
  ownerUserName: user.username,
  token: user.idToken,
  tenant: 'newww'
}
const apps = await getApps({ token: user.idToken, tenant: 'newww' })
await createApp({
  tenant: 'newww',
  token: user.idToken,
  app: 'appname'
}
```