### PR TITLE
Do not follow if there's no config.userId

### DIFF
--- a/src/utils/configFile.js
+++ b/src/utils/configFile.js
@@ -60,7 +60,7 @@ export const readConfigFile = () => {
 
 /*
  * Write Config File
- * - Writes a .serverlessrc file on the local machine in the root dir.
+ * - Writes a .serverlessrc file on the local machine in the root dir
  */
 
 export const writeConfigFile = (data) => {

--- a/src/utils/configFile.js
+++ b/src/utils/configFile.js
@@ -79,6 +79,9 @@ export const writeConfigFile = (data) => {
 
 export const getLoggedInUser = () => {
   const config = readConfigFile()
+  if (!config.userId) {
+    return null
+  }
   const user = get(['users', config.userId, 'dashboard'], config)
   if (!user || !user.username) {
     return null // user is logged out

--- a/src/utils/configFile.test.js
+++ b/src/utils/configFile.test.js
@@ -1,0 +1,32 @@
+jest.mock('write-file-atomic', () => ({})) // apparently needs stuff from `fs` to even be imported
+
+describe('configFile', () => {
+  it('getLoggedInUser returns user!', () => {
+    const { getLoggedInUser } = require('./configFile')
+    jest.mock('fs', () => ({
+      readFileSync: jest.fn().mockReturnValue(
+        new Buffer(
+          JSON.stringify({
+            userId: 'USER',
+            users: {
+              USER: {
+                dashboard: {
+                  username: 'USERNAME',
+                  accessKeys: 'KEYS',
+                  idToken: 'TOKEN'
+                }
+              }
+            }
+          })
+        )
+      ),
+      existsSync: jest.fn().mockReturnValue(true)
+    }))
+    expect(getLoggedInUser()).toEqual({
+      userId: 'USER',
+      username: 'USERNAME',
+      accessKeys: 'KEYS',
+      idToken: 'TOKEN'
+    })
+  })
+})

--- a/src/utils/configFile.test.js
+++ b/src/utils/configFile.test.js
@@ -4,7 +4,7 @@ describe('configFile', () => {
   it('getLoggedInUser returns user!', () => {
     const { getLoggedInUser } = require('./configFile')
     jest.mock('fs', () => ({
-      readFileSync: jest.fn().mockReturnValue(
+      readFileSync: jest.fn().mockReturnValueOnce(
         new Buffer(
           JSON.stringify({
             userId: 'USER',
@@ -28,5 +28,28 @@ describe('configFile', () => {
       accessKeys: 'KEYS',
       idToken: 'TOKEN'
     })
+  })
+
+  it("getLoggedInUser doesn't return user when there's no userId", () => {
+    const { getLoggedInUser } = require('./configFile')
+    jest.mock('fs', () => ({
+      readFileSync: jest.fn().mockReturnValueOnce(
+        new Buffer(
+          JSON.stringify({
+            users: {
+              undefined: {
+                dashboard: {
+                  username: 'USERNAME',
+                  accessKeys: 'KEYS',
+                  idToken: 'TOKEN'
+                }
+              }
+            }
+          })
+        )
+      ),
+      existsSync: jest.fn().mockReturnValue(true)
+    }))
+    expect(getLoggedInUser()).toEqual(null)
   })
 })


### PR DESCRIPTION
Otherwise config as following is considered as one with logged in user:

```javascript
{
  ...
  "users": {
    "undefined": {
      ...
      "dashboard": {
        ...
        "username": "whatever"
      }
    }
  }
}
```

(and I happened to have one like that due to [other bug](https://github.com/serverless/enterprise-plugin/pull/206))

