### PR TITLE
Check token expiration from idToken

### DIFF
--- a/src/accessKeys/accessKeys.test.js
+++ b/src/accessKeys/accessKeys.test.js
@@ -16,6 +16,16 @@ jest.mock('../fetch', () =>
   )
 )
 
+Date.now = jest.fn().mockReturnValue(1548263344735)
+
+jest.mock('jwt-decode', () =>
+  jest.fn().mockReturnValue(
+    Promise.resolve({
+      exp: 1548263344735 - 10000
+    })
+  )
+)
+
 jest.mock('../utils', () => ({
   readConfigFile: jest.fn().mockReturnValue({
     userId: 'userId',

--- a/src/login/refreshToken.js
+++ b/src/login/refreshToken.js
@@ -1,6 +1,7 @@
 import fetch from '../fetch'
 import platformConfig from '../config'
 import * as utils from '../utils'
+import jwtDecode from 'jwt-decode'
 
 const refreshToken = async () => {
   const configFile = utils.readConfigFile()
@@ -10,7 +11,8 @@ const refreshToken = async () => {
   }
 
   // id token not expired, no need to renew
-  if (Number(configFile.users[currentId].dashboard.expiresAt) > Date.now()) {
+  const decoded = jwtDecode(configFile.users[currentId].dashboard.idToken)
+  if (Number(decoded.exp) * 1000 > Date.now()) {
     return
   }
 

--- a/src/login/refreshToken.test.js
+++ b/src/login/refreshToken.test.js
@@ -1,5 +1,7 @@
 import refreshToken from './refreshToken'
 import fetch from 'isomorphic-fetch'
+import jwtDecode from 'jwt-decode'
+
 import * as utils from '../utils'
 
 jest.mock('isomorphic-fetch', () =>
@@ -17,6 +19,14 @@ jest.mock('isomorphic-fetch', () =>
   )
 )
 
+jest.mock('jwt-decode', () =>
+  jest.fn().mockReturnValue(
+    Promise.resolve({
+      exp: 1548263344735 - 10000
+    })
+  )
+)
+
 Date.now = jest.fn().mockReturnValue(1548263344735)
 
 jest.mock('../utils', () => ({
@@ -25,7 +35,7 @@ jest.mock('../utils', () => ({
     users: {
       userId: {
         dashboard: {
-          expiresAt: 1548263344735 - 10000,
+          idToken: 'idToken',
           refreshToken: 'refreshToken'
         }
       }
@@ -39,6 +49,7 @@ describe('refreshToken', () => {
   it('refreshes tokens', async () => {
     await refreshToken()
     expect(utils.readConfigFile).toBeCalledWith()
+    expect(jwtDecode).toBeCalledWith('idToken')
     expect(fetch).toBeCalledWith('https://api.serverless.com/core/tokens/refresh', {
       body: JSON.stringify({ refreshToken: 'refreshToken' }),
       headers: {},


### PR DESCRIPTION
[PLAT-1426](https://serverlessteam.atlassian.net/browse/PLAT-1426).

Reads the idToken expiry from the decoded idToken itself, rather than using the `expiresAt` property that refers to the accessToken.