### PR TITLE
Local host for backend

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ const platformStage = process.env.SERVERLESS_PLATFORM_STAGE || 'prod'
 const config = {
   local: {
     frontendUrl: 'http://localhost:3000/',
-    backendUrl: 'https://api.serverless-dev.com/core/',
+    backendUrl: 'https://localhost:3011/core/',
     loginBrokerUrl: 'https://api.serverless-dev.com/login/',
     logDestinationUrl: 'https://api.serverless-dev.com/malt/',
     auth0Domain: 'serverlessdev.auth0.com',


### PR DESCRIPTION
Use localhost:3011 for LOCAL to allow you to login to a local cli.
This fixes a bad-request error that would result from Auth0 storing the user's auth code along with the redirectURL provided by the originating requester.

Issue:
1. you log in from the CLI with SERVERLESS_PLATFORM_STAGE=local sls login
2. that bounces you through localhost:3000 frontend -> auth0
3. Auth0 STORES the domain localhost:3000 along with your auth code to fetch tokens
4. Auth0 redirects you back to localhost:3000 frontend
5. localhost:3000 frontend passes that code to the server (in sdk versions 2.1.0 and earlier)
6. CLI then requests from api.serverless-dev.com for tokens with your code
7. DEV dashboard calls out to auth0 with your code and sets the redirectURL to dashboard.serverless-dev.com (Dev frontend)
8. auth0 returns a bad client ID because dashboard.serverless-dev.com is the redirect URL, not localhost:3000