### PR TITLE
Update username save

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ const platformStage = process.env.SERVERLESS_PLATFORM_STAGE || 'prod'
 const config = {
   local: {
     frontendUrl: 'http://localhost:3000/',
-    backendUrl: 'https://localhost:3011/core/',
+    backendUrl: 'http://localhost:3011/core/',
     loginBrokerUrl: 'https://api.serverless-dev.com/login/',
     logDestinationUrl: 'https://api.serverless-dev.com/malt/',
     auth0Domain: 'serverlessdev.auth0.com',

--- a/src/login/login.js
+++ b/src/login/login.js
@@ -56,7 +56,7 @@ const login = async (tenant) => {
       accessToken: data.access_token,
       idToken: data.id_token,
       expiresAt: Date.now() + data.expires_in,
-      username: decoded.nickname
+      username: data.username
     }
   }
 

--- a/src/login/login.js
+++ b/src/login/login.js
@@ -44,6 +44,7 @@ const login = async (tenant) => {
 
   const decoded = jwtDecode(data.id_token)
   const id = decoded.tracking_id || decoded.sub
+  const expiresAt = data.expires_in ? Date.now() + data.expires_in : data.expires_at
   configFile.userId = id
   configFile.users = configFile.users || {}
   configFile.users[id] = {
@@ -55,7 +56,7 @@ const login = async (tenant) => {
       refreshToken: data.refresh_token,
       accessToken: data.access_token,
       idToken: data.id_token,
-      expiresAt: Date.now() + data.expires_in,
+      expiresAt: expiresAt,
       username: data.username
     }
   }


### PR DESCRIPTION
Makes a few changes to saving data in the serverlessrc file from the Websocket connection, specifically:

1. It uses `data.username` (passed down from the Websocket) rather than the `nickname` property from the decoded JWT. The nickname property is the username (GitHub) or beginning of email address (Email / Google) rather than our SFE username.

2. Based on whether the message is sent from login or register, we might receive an `expires_in` or `expires_at` property. It normalizes how it handles this to cover both cases.

Also updated the config to use http for a local backend.