### PR TITLE
chore: Upgrade https-proxy-agent to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.1",
-    "https-proxy-agent": "^3.0.0",
+    "https-proxy-agent": "^4.0.0",
     "is-docker": "^1.1.0",
     "isomorphic-fetch": "^2.2.1",
     "jwt-decode": "^2.2.0",


### PR DESCRIPTION
Similar to https://github.com/serverless/serverless/pull/7182