### PR TITLE
Remove internal Snyk integration

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,0 @@
-# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.5
-ignore: {}
-patch: {}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
 language: node_js
 sudo: false
 node_js:
-- '10.15'
-- 8
-- 6
+  - '10.15'
+  - 8
+  - 6
 before_install:
-- npm run setup:ci
+  - npm run setup:ci
 install:
-- npm run setup
+  - npm run setup
 script:
-- npm run lint
-- npm run test:ci
+  - npm run lint
+  - npm run test:ci
 before_deploy:
-- snyk monitor --org=serverless
-- node ./scripts/updatePreReleaseVersion.js
+  - snyk monitor --org=serverless
+  - node ./scripts/updatePreReleaseVersion.js
 deploy:
   # production releases
   - provider: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ script:
   - npm run lint
   - npm run test:ci
 before_deploy:
-  - snyk monitor --org=serverless
   - node ./scripts/updatePreReleaseVersion.js
 deploy:
   # production releases

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "setup": "./scripts/setup.sh",
     "setup:ci": "./scripts/setup-ci.sh",
     "test": "./scripts/test.sh",
-    "test:ci": "snyk test && ./scripts/test-ci.sh",
+    "test:ci": "./scripts/test-ci.sh",
     "watch": "./scripts/watch.sh"
   },
   "dependencies": {
@@ -55,8 +55,7 @@
     "jest-cli": "^21.2.0",
     "lint-staged": "7.1.3",
     "pre-commit": "^1.2.2",
-    "prettier": "^1.17.1",
-    "snyk": "^1.163.3"
+    "prettier": "^1.17.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
It currently fails CI: https://travis-ci.com/serverless/platform-sdk/jobs/275505824

While, as in other repositories, we have configured a Snyk task which externally confirms on security vulnerabilities in each PR