### PR TITLE
PLAT-2201 Configure `getService` endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/platform-sdk",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "Serverless Platform SDK",
   "author": "Serverless, Inc.",
   "license": "Apache-2.0",

--- a/src/service/getService.js
+++ b/src/service/getService.js
@@ -1,0 +1,14 @@
+import fetch from '../fetch'
+import platformConfig from '../config'
+
+export default async ({ accessKey, app, tenant, service }) => {
+  const response = await fetch(
+    `${platformConfig.backendUrl}tenants/${tenant}/applications/${app}/services/${service}`,
+    {
+      method: 'GET',
+      headers: { Authorization: `bearer ${accessKey}` }
+    }
+  )
+
+  return response.json()
+}

--- a/src/service/getService.test.js
+++ b/src/service/getService.test.js
@@ -1,0 +1,66 @@
+import fetch from 'isomorphic-fetch'
+import { getService } from '.'
+import platformConfig from '../config'
+
+jest.mock('isomorphic-fetch', () =>
+  jest.fn().mockReturnValue(
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        appId: 'test',
+        tenantName: 'test',
+        appName: 'test',
+        serviceName: 'test',
+        stagesAndRegions: {
+          dev: {
+            'us-east-1': {
+              outputs: {},
+              archived: false,
+              createdAt: '2019-12-23T13:49:26.129Z',
+              logsRoleArn: 'arn:aws:iam::test',
+              updatedAt: '2020-01-17T15:07:32.565Z',
+              lastActionBy: 'test'
+            }
+          }
+        },
+        vcs: {
+          type: 'git',
+          branch: 'dashboard',
+          commit: '6713d41076aab4e505ba2dca704fe491968d7bdb',
+          commitMessage: 'Update',
+          committerEmail: 'test@test.com',
+          relativePath: ''
+        },
+        lastActionBy: 'test',
+        isArchived: false,
+        createdAt: '2019-12-23T13:49:26.157Z',
+        updatedAt: '2020-01-17T15:07:32.592Z',
+        stateItems: []
+      })
+    })
+  )
+)
+
+afterAll(() => jest.restoreAllMocks())
+
+describe('getService', () => {
+  test('it fetches data', async () => {
+    const data = {
+      accessKey: 'test',
+      app: 'someapp',
+      tenant: 'sometenant',
+      service: 'somename'
+    }
+
+    await getService(data)
+
+    expect(fetch).toBeCalledWith(
+      `${platformConfig.backendUrl}tenants/${data.tenant}/applications/${data.app}/services/${data.service}`,
+      {
+        method: 'GET',
+        headers: { Authorization: `bearer ${data.accessKey}` }
+      }
+    )
+  })
+})

--- a/src/service/index.js
+++ b/src/service/index.js
@@ -1,2 +1,3 @@
 export { default as archiveService } from './archiveService'
 export { default as getServiceUrl } from './getServiceUrl'
+export { default as getService } from './getService'


### PR DESCRIPTION
Allows to resolve all _outputs_ for given _service_ in given _stage_, which in turn is needed for `output list` CLI command.