### PR TITLE
Ensure user.accessKeys when updating it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@serverless/platform-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Serverless Platform SDK",
   "author": "Serverless, Inc.",
   "license": "Apache-2.0",

--- a/src/accessKeys/accessKeys.js
+++ b/src/accessKeys/accessKeys.js
@@ -51,6 +51,9 @@ const getAccessKeyForTenant = async (tenant) => {
   // Check if in config file, if not, & if possible, create one
   if (!user.accessKeys || !user.accessKeys[tenant]) {
     if (user.idToken) {
+      if (!user.accessKeys) {
+        user.accessKeys = {}
+      }
       user.accessKeys[tenant] = await createAccessKeyForTenant(tenant)
       utils.writeConfigFile({
         users: {


### PR DESCRIPTION
Just approached a following error, after just adding `org` and `app` settings to my SFO service:

```
 % AWS_PROFILE=test sls package
 
  Type Error ---------------------------------------------
 
  TypeError: Cannot set property 'medikoo' of undefined
      at _callee2$ (/Users/medikoo/npm-packages/@serverless/platform-sdk/src/accessKeys/accessKeys.js:37:31)
      at tryCatch (/usr/local/lib/node_modules/regenerator-runtime/runtime.js:45:40)
      at Generator.invoke [as _invoke] (/usr/local/lib/node_modules/regenerator-runtime/runtime.js:274:22)
      at Generator.prototype.<computed> [as next] (/usr/local/lib/node_modules/regenerator-runtime/runtime.js:97:21)
      at step (/Users/medikoo/npm-packages/@serverless/platform-sdk/dist/accessKeys/accessKeys.js:28:191)
      at /Users/medikoo/npm-packages/@serverless/platform-sdk/dist/accessKeys/accessKeys.js:28:361
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
 
     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.
 
  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com
 
  Your Environment Information ---------------------------
     Operating System:          darwin
     Node Version:              14.3.0
     Framework Version:         1.71.3
     Plugin Version:            3.6.12
     SDK Version:               2.3.0
     Components Version:        2.30.11

```

I'm on a new setup and previously I've logged in with a platform-client SDK, it appears that created a state of `.serverlessrc` which can lead to crashes on `platform-sdk`.

This patch ensures platform SDK properly recovers from such issue

