### PR TITLE
Upgrade babel and jest

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,12 @@
 {
   "presets": [
-    ["env", {
+    ["@babel/preset-env", {
       "targets": {
         "node": "4"
       }
     }]
   ],
   "plugins": [
-    ["transform-object-rest-spread", { "useBuiltIns": true }]
+    ["@babel/plugin-proposal-object-rest-spread", { "useBuiltIns": true }]
   ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-  - '10.15'
-  - 8
-  - 6
+  - 14
+  - 12
+  - 10
 before_install:
   - npm run setup:ci
 install:

--- a/package.json
+++ b/package.json
@@ -43,16 +43,17 @@
     "ws": "<7.0.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.3",
-    "babel-jest": "^21.2.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "@babel/cli": "^7.10.5",
+    "@babel/core": "^7.11.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
+    "@babel/preset-env": "^7.11.0",
+    "babel-jest": "^26.2.2",
     "babel-preset-env": "^1.6.1",
     "eslint": "^4.19.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-import": "^2.17.2",
     "eslint-plugin-prettier": "^2.6.1",
-    "jest-cli": "^21.2.0",
+    "jest-cli": "^26.2.2",
     "lint-staged": "7.1.3",
     "pre-commit": "^1.2.2",
     "prettier": "^1.17.1"

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   },
   "dependencies": {
     "chalk": "^2.4.1",
+    "cross-fetch": "^3.0.5",
     "https-proxy-agent": "^4.0.0",
     "is-docker": "^1.1.0",
-    "isomorphic-fetch": "^2.2.1",
     "jwt-decode": "^2.2.0",
     "opn": "^5.5.0",
     "querystring": "^0.2.0",

--- a/src/apps/createApp.test.js
+++ b/src/apps/createApp.test.js
@@ -1,8 +1,8 @@
 import { createApp } from './'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import platformConfig from '../config'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue({
     ok: true,
     json: async () => {}

--- a/src/apps/getApp.test.js
+++ b/src/apps/getApp.test.js
@@ -1,9 +1,9 @@
 import { getApp } from './'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import platformConfig from '../config'
 import refreshToken from '../login/refreshToken'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue({
     ok: true,
     json: async () => {}

--- a/src/apps/getApps.test.js
+++ b/src/apps/getApps.test.js
@@ -1,9 +1,9 @@
 import { getApps } from './'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import platformConfig from '../config'
 import refreshToken from '../login/refreshToken'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue({
     ok: true,
     json: async () => {}

--- a/src/core/getMetadata.test.js
+++ b/src/core/getMetadata.test.js
@@ -1,7 +1,7 @@
 import getMetadata from './getMetadata'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue(
     Promise.resolve({
       ok: true,

--- a/src/deployProfiles/createDeploymentProfile.test.js
+++ b/src/deployProfiles/createDeploymentProfile.test.js
@@ -1,7 +1,7 @@
 import { createDeploymentProfile } from './'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue({
     ok: true,
     json: async () => ({

--- a/src/deployProfiles/getDeployProfile.test.js
+++ b/src/deployProfiles/getDeployProfile.test.js
@@ -1,7 +1,7 @@
 import { getDeployProfile } from './'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockImplementation((url) => {
     if (url.endsWith('/app-with-profile/profileValue')) {
       return {

--- a/src/deployProfiles/getDeployProfiles.test.js
+++ b/src/deployProfiles/getDeployProfiles.test.js
@@ -1,7 +1,7 @@
 import { getDeployProfiles } from './'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockImplementation((url) => {
     if (url.endsWith('/org-with-profile/deploymentProfiles')) {
       return {

--- a/src/deployProfiles/setDefaultDeploymentProfile.test.js
+++ b/src/deployProfiles/setDefaultDeploymentProfile.test.js
@@ -1,7 +1,7 @@
 import { setDefaultDeploymentProfile } from './'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue({
     ok: true,
     json: async () => ({

--- a/src/deployments/index.test.js
+++ b/src/deployments/index.test.js
@@ -1,4 +1,4 @@
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import { getAccessKeyForTenant } from '../accessKeys'
 import Deployment from './'
 import { version as packageJsonVersion } from '../../package.json'
@@ -6,7 +6,7 @@ import { version as packageJsonVersion } from '../../package.json'
 jest.mock('../accessKeys', () => ({
   getAccessKeyForTenant: jest.fn().mockReturnValue('access-key')
 }))
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue(
     Promise.resolve({
       ok: true,

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import https from 'https'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import HttpsProxyAgent from 'https-proxy-agent'
 import { checkHttpResponse } from './utils'
 import { version as currentVersion } from '../package.json'

--- a/src/fetch.test.js
+++ b/src/fetch.test.js
@@ -1,10 +1,10 @@
 import { configureFetchDefaults, default as wrappedFetch } from './fetch'
 import { version as currentVersion } from '../package.json'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import { Agent } from 'https'
 import HttpsProxyAgent from 'https-proxy-agent'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue({
     ok: true,
     json: async () => ({ destinationArn: 'arn:dest' })

--- a/src/login/openBrowser.test.js
+++ b/src/login/openBrowser.test.js
@@ -18,6 +18,8 @@ describe('openBrowser', () => {
       platform,
       env: { DISPLAY }
     } = process)
+    // Make the process variable editable (throws an error in Node v14)
+    process = { ...process, env: { ...process.env } }
     process.env.DISPLAY = ':0'
   })
   afterAll(() => {

--- a/src/login/refreshToken.test.js
+++ b/src/login/refreshToken.test.js
@@ -1,10 +1,10 @@
 import refreshToken from './refreshToken'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import jwtDecode from 'jwt-decode'
 
 import * as utils from '../utils'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue(
     Promise.resolve({
       ok: true,

--- a/src/logs/createDestination.test.js
+++ b/src/logs/createDestination.test.js
@@ -1,8 +1,8 @@
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import platformConfig from '../config'
 import { getLogDestination } from './'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue(
     Promise.resolve({
       ok: true,

--- a/src/logs/removeDestination.test.js
+++ b/src/logs/removeDestination.test.js
@@ -1,8 +1,8 @@
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import platformConfig from '../config'
 import { removeLogDestination } from './'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue(
     Promise.resolve({
       ok: true,

--- a/src/register/register.test.js
+++ b/src/register/register.test.js
@@ -1,7 +1,7 @@
 import { register } from './'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue(
     Promise.resolve({
       ok: true,

--- a/src/safeguards/getSafeguards.test.js
+++ b/src/safeguards/getSafeguards.test.js
@@ -1,6 +1,6 @@
 import getSafeguards from './getSafeguards'
-import fetch from 'isomorphic-fetch'
-jest.mock('isomorphic-fetch', () =>
+import fetch from 'cross-fetch'
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue({
     ok: true,
     json: async () => [
@@ -26,7 +26,9 @@ describe('getSafeguards', () => {
       tenant: 'tenant',
       stage: 'stage'
     })
-    expect(fetch).toBeCalledWith(
+    expect(
+      fetch
+    ).toBeCalledWith(
       'https://api.serverless.com/core/tenants/tenant/safeguards/policies/?appName=app',
       { method: 'GET', headers: { Authorization: `bearer accessKey` } }
     )

--- a/src/secrets/getSecret.test.js
+++ b/src/secrets/getSecret.test.js
@@ -1,6 +1,6 @@
 import getSecret from './getSecret'
-import fetch from 'isomorphic-fetch'
-jest.mock('isomorphic-fetch', () =>
+import fetch from 'cross-fetch'
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue({
     ok: true,
     json: async () => ({ destinationArn: 'arn:dest' })

--- a/src/service/archiveService.test.js
+++ b/src/service/archiveService.test.js
@@ -1,8 +1,8 @@
 import { archiveService } from './'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import platformConfig from '../config'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue({
     ok: true,
     json: async () => {}

--- a/src/service/getService.test.js
+++ b/src/service/getService.test.js
@@ -1,8 +1,8 @@
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import { getService } from '.'
 import platformConfig from '../config'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue(
     Promise.resolve({
       ok: true,

--- a/src/stateVariables/index.test.js
+++ b/src/stateVariables/index.test.js
@@ -1,6 +1,6 @@
 import { getStateVariable } from './index'
-import fetch from 'isomorphic-fetch'
-jest.mock('isomorphic-fetch', () =>
+import fetch from 'cross-fetch'
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue({
     ok: true,
     status: 200,

--- a/src/tenants/createTenant.test.js
+++ b/src/tenants/createTenant.test.js
@@ -1,8 +1,8 @@
 import { createTenant } from './'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import platformConfig from '../config'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue({
     ok: true,
     json: async () => {}

--- a/src/tenants/listTenants.test.js
+++ b/src/tenants/listTenants.test.js
@@ -1,8 +1,8 @@
 import { listTenants } from './'
-import fetch from 'isomorphic-fetch'
+import fetch from 'cross-fetch'
 import platformConfig from '../config'
 
-jest.mock('isomorphic-fetch', () =>
+jest.mock('cross-fetch', () =>
   jest.fn().mockReturnValue({
     ok: true,
     json: async () => {}

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -4,7 +4,7 @@ import os from 'os'
 import { readConfigFile, getLoggedInUser } from './index.js'
 
 jest.mock('fs', () => ({
-  ...require.requireActual('fs'),
+  ...jest.requireActual('fs'),
   existsSync: jest.fn().mockReturnValue(true),
   readFileSync: jest.fn().mockReturnValue(
     JSON.stringify({


### PR DESCRIPTION
This PR updates Babel to v7 and Jest to v26. Because it's always nice to work with up-to-date dependencies. Also, it fixes tests failures on Node v14:
```
The module factory of `jest.mock()` is not allowed to reference any out-of-scope variables.
    Invalid variable access: Buffer
    Whitelisted objects: ....
    Note: This is a precaution to guard against uninitialized mock variables. If it is ensured that the mock is required lazily, variable names prefixed with `mock` are permitted.
```

It also updates the CI to use Node 10,12 and 14 instead of 6,8,10 (Node 6 and 8 have been EOL for quite some time now)